### PR TITLE
Phabricator T139757: Find duplicate statements

### DIFF
--- a/frontend/freebase2wikidata.js
+++ b/frontend/freebase2wikidata.js
@@ -981,7 +981,30 @@ $(function() {
             }
           } else {
             // New object
-            createNewStatement(property, freebaseObject);
+            var isDuplicate = false;
+            for (var c = 0; c < wikidataClaims[property].length; c++) {
+              var wikidataObject = wikidataClaims[property][c];
+              var wikidataObjQid = wikidataObject.mainsnak.datavalue.value.id;
+              var freebaseObjQid = freebaseObject.object;
+
+              // Duplicate found
+              if (wikidataObjQid === freebaseObjQid) {
+                isDuplicate = true;
+                debug.log('Duplicate found! ' + property + ':'
+                                + wikidataObjQid);
+
+                // Add new sources to existing statement
+                prepareNewSources(
+                    property,
+                    freebaseObject,
+                    wikidataObject
+                );
+              }
+            }
+
+            if (!isDuplicate) {
+              createNewStatement(property, freebaseObject);
+            }
           }
         }
       } else {
@@ -1144,8 +1167,14 @@ $(function() {
       label.textContent = newLabel;
       // Append the references
       container = container
-          .querySelector('.wikibase-statementview-references')
-          .querySelector('.wikibase-listview');
+          .querySelector('.wikibase-statementview-references');
+      // Create wikibase-listview if not found
+      if (!container.querySelector('.wikibase-listview')) {
+        var sourcesListView = document.createElement('div');
+        sourcesListView.className = 'wikibase-listview';
+        container.insertBefore(sourcesListView, container.firstChild);
+      }
+      container = container.querySelector('.wikibase-listview');
       container.appendChild(fragment);
     });
   }

--- a/frontend/freebase2wikidata.js
+++ b/frontend/freebase2wikidata.js
@@ -984,14 +984,11 @@ $(function() {
             var isDuplicate = false;
             for (var c = 0; c < wikidataClaims[property].length; c++) {
               var wikidataObject = wikidataClaims[property][c];
-              var wikidataObjQid = wikidataObject.mainsnak.datavalue.value.id;
-              var freebaseObjQid = freebaseObject.object;
 
-              // Duplicate found
-              if (wikidataObjQid === freebaseObjQid) {
+              if (wikidataObject.mainsnak.snaktype === 'value' &&
+                  jsonToTsvValue(wikidataObject.mainsnak.datavalue) === freebaseObject.object) {
                 isDuplicate = true;
-                debug.log('Duplicate found! ' + property + ':'
-                                + wikidataObjQid);
+                debug.log('Duplicate found! ' + property + ':' + freebaseObject.object);
 
                 // Add new sources to existing statement
                 prepareNewSources(


### PR DESCRIPTION
This is a solution of phabricator ticket [T139757](https://phabricator.wikimedia.org/T139757) proposed to me by @marfox.

Now, there are duplicate statements ("Republic of Florence"):
![schermata 2017-03-14 alle 14 38 47 1](https://cloud.githubusercontent.com/assets/3373979/23903273/3e628466-08c4-11e7-9532-721633ccb887.png)

Solution, new references are appended to existing statement:
![schermata 2017-03-14 alle 14 26 04](https://cloud.githubusercontent.com/assets/3373979/23903279/478952b8-08c4-11e7-9146-078fd234cdc6.png) 

