### PR TITLE
add referencePreview feature

### DIFF
--- a/frontend/freebase2wikidata.css
+++ b/frontend/freebase2wikidata.css
@@ -31,6 +31,10 @@
   display: block;
 }
 
+.wikibase-referenceview .wikibase-snaklistview-listview .wikibase-snakview {
+  min-height: 2.1em;
+}
+
 .mw-notification-tag-ps-error {
   background-color: #fee7e6 !important;
   border: 1px solid #b32424 !important;

--- a/frontend/freebase2wikidata.css
+++ b/frontend/freebase2wikidata.css
@@ -45,5 +45,136 @@
 }
 
 #n-ps-anchor-btt{
-  font-size: 0.75em;
+ font-size: 0.75em;
+}
+
+.preview-button{
+  max-width: 80%;
+  display: block;
+  overflow: hidden;
+  cursor: pointer;
+  text-align: center;
+  justify-content: center;
+  white-space: nowrap;
+  text-decoration: none !important;
+  text-transform: capitalize;
+  color: #FFFFFF;
+  background: #161616;
+  border: 0 none;
+  border-radius: 4px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+.overlay {
+    height: 100%;
+    width: 0;
+    position: fixed;
+    z-index: 1;
+    left: 0;
+    top: 0;
+    background-color: rgb(0,0,0); /*fallback*/
+    background-color: rgba(0,0,0, 0.88);
+    overflow-x: hidden;
+    transition: 0.5s;
+}
+
+.overlay-content {
+    position: relative;
+    top: 25%;
+    width: 100%;
+    text-align: center;
+    margin-top: 30px;
+}
+
+.overlay ul{
+  list-style-type: none;
+  list-style-image: none;
+}
+
+.overlay h1{
+	font-size: 1.6vmax;
+	overflow-wrap: break-word;
+	margin-top: 10px;
+	color: white;
+}
+
+.overlay h1 a {
+    text-decoration: none;
+    color: #FF0000;
+    cursor: pointer; 
+    cursor: hand;
+}
+
+.overlay .f2w-button{
+	padding: 3px 5px 3px 5px;
+	margin: 2px 3px 10px 3px;
+	overflow: hidden;
+	cursor: pointer;
+	text-align: center;
+	justify-content: center;
+	white-space: nowrap;
+	text-decoration: none !important;
+	text-transform: none;
+	text-transform: capitalize;
+	color: black;
+	background: white;
+	border: 0 none;
+	border-radius: 4px;
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+}
+
+.overlay .closebtn {
+    position: absolute;
+    top: 20px;
+    right: 45px;
+    font-size: 60px;
+    padding: 8px;
+    text-decoration: none;
+    color: #818181;
+    display: block;
+    transition: 0.3s;
+}
+
+#blackboard{
+    margin: 40px auto;
+    max-width: 650px;
+    line-height:1.6;
+    font-size: 18px;
+    color: white;
+    padding: 0 10px;
+    font-family: 'Lato', sans-serif;
+}
+
+.highlight{
+    color:black;
+    background-color:yellow;
+    font-style: italic;
+}
+
+@media screen and (max-height: 450px) {
+    .overlay a {font-size: 20px}
+    .overlay .closebtn {
+        font-size: 40px;
+        top: 15px;
+        right: 35px;
+    }
+}
+
+.loader {
+    border: 16px solid white;
+    border-top: 16px solid black;
+    border-radius: 50%;
+    height: 50px;
+    width: 50px;
+    margin: 30px auto;
+    animation: spin 2s linear infinite;
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
 }

--- a/frontend/freebase2wikidata.css
+++ b/frontend/freebase2wikidata.css
@@ -45,7 +45,7 @@
 }
 
 #n-ps-anchor-btt{
- font-size: 0.75em;
+  font-size: 0.75em;
 }
 
 .preview-button{
@@ -68,24 +68,24 @@
 }
 
 .overlay {
-    height: 100%;
-    width: 0;
-    position: fixed;
-    z-index: 1;
-    left: 0;
-    top: 0;
-    background-color: rgb(0,0,0); /*fallback*/
-    background-color: rgba(0,0,0, 0.88);
-    overflow-x: hidden;
-    transition: 0.5s;
+  height: 100%;
+  width: 0;
+  position: fixed;
+  z-index: 1;
+  left: 0;
+  top: 0;
+  background-color: rgb(0,0,0); /*fallback*/
+  background-color: rgba(0,0,0, 0.88);
+  overflow-x: hidden;
+  transition: 0.5s;
 }
 
 .overlay-content {
-    position: relative;
-    top: 25%;
-    width: 100%;
-    text-align: center;
-    margin-top: 30px;
+  position: relative;
+  top: 25%;
+  width: 100%;
+  text-align: center;
+  margin-top: 30px;
 }
 
 .overlay ul{
@@ -94,87 +94,87 @@
 }
 
 .overlay h1{
-	font-size: 1.6vmax;
-	overflow-wrap: break-word;
-	margin-top: 10px;
-	color: white;
+  font-size: 1.6vmax;
+  overflow-wrap: break-word;
+  margin-top: 10px;
+  color: white;
 }
 
 .overlay h1 a {
-    text-decoration: none;
-    color: #FF0000;
-    cursor: pointer; 
-    cursor: hand;
+  text-decoration: none;
+  color: #FF0000;
+  cursor: pointer; 
+  cursor: hand;
 }
 
 .overlay .f2w-button{
-	padding: 3px 5px 3px 5px;
-	margin: 2px 3px 10px 3px;
-	overflow: hidden;
-	cursor: pointer;
-	text-align: center;
-	justify-content: center;
-	white-space: nowrap;
-	text-decoration: none !important;
-	text-transform: none;
-	text-transform: capitalize;
-	color: black;
-	background: white;
-	border: 0 none;
-	border-radius: 4px;
-	-webkit-appearance: none;
-	-moz-appearance: none;
-	appearance: none;
+  padding: 3px 5px 3px 5px;
+  margin: 2px 3px 10px 3px;
+  overflow: hidden;
+  cursor: pointer;
+  text-align: center;
+  justify-content: center;
+  white-space: nowrap;
+  text-decoration: none !important;
+  text-transform: none;
+  text-transform: capitalize;
+  color: black;
+  background: white;
+  border: 0 none;
+  border-radius: 4px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
 }
 
 .overlay .closebtn {
-    position: absolute;
-    top: 20px;
-    right: 45px;
-    font-size: 60px;
-    padding: 8px;
-    text-decoration: none;
-    color: #818181;
-    display: block;
-    transition: 0.3s;
+  position: absolute;
+  top: 20px;
+  right: 45px;
+  font-size: 60px;
+  padding: 8px;
+  text-decoration: none;
+  color: #818181;
+  display: block;
+  transition: 0.3s;
 }
 
 #blackboard{
-    margin: 40px auto;
-    max-width: 650px;
-    line-height:1.6;
-    font-size: 18px;
-    color: white;
-    padding: 0 10px;
-    font-family: 'Lato', sans-serif;
+  margin: 40px auto;
+  max-width: 650px;
+  line-height:1.6;
+  font-size: 18px;
+  color: white;
+  padding: 0 10px;
+  font-family: 'Lato', sans-serif;
 }
 
 .highlight{
-    color:black;
-    background-color:yellow;
-    font-style: italic;
+  color:black;
+  background-color:yellow;
+  font-style: italic;
 }
 
 @media screen and (max-height: 450px) {
-    .overlay a {font-size: 20px}
-    .overlay .closebtn {
-        font-size: 40px;
-        top: 15px;
-        right: 35px;
-    }
+  .overlay a {font-size: 20px}
+  .overlay .closebtn {
+    font-size: 40px;
+    top: 15px;
+    right: 35px;
+  }
 }
 
 .loader {
-    border: 16px solid white;
-    border-top: 16px solid black;
-    border-radius: 50%;
-    height: 50px;
-    width: 50px;
-    margin: 30px auto;
-    animation: spin 2s linear infinite;
+  border: 16px solid white;
+  border-top: 16px solid black;
+  border-radius: 50%;
+  height: 50px;
+  width: 50px;
+  margin: 30px auto;
+  animation: spin 2s linear infinite;
 }
 
 @keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
 }

--- a/frontend/freebase2wikidata.css
+++ b/frontend/freebase2wikidata.css
@@ -62,8 +62,8 @@
   white-space: nowrap;
   text-decoration: none !important;
   text-transform: capitalize;
-  color: #FFFFFF;
-  background: #161616;
+  color: #0645ad;
+  background: #FFF;
   border: 0 none;
   border-radius: 4px;
   -webkit-appearance: none;

--- a/frontend/freebase2wikidata.js
+++ b/frontend/freebase2wikidata.js
@@ -261,12 +261,11 @@ $(function() {
     return qidRegEx.test(title) ? title : false;
   }
 
-    ps.openNav = function openNav(itemLabel, propertyLabel, propertyValue, referenceURL, referenceItem) {
+    ps.openNav = function openNav(itemLabel, propertyLabel, propertyValue, referenceURL, buttons) {
         $('#myNav').width('100%');
 
         var blackboard = $('#blackboard');
 
-        var buttons = $(referenceItem).closest('.wikibase-referenceview.listview-item.wikibase-toolbar-item.new-source').children().find('.f2w-button.f2w-source');
         blackboard.append(buttons.eq(0).clone(true, true));
         blackboard.append(buttons.eq(1).clone(true, true));
 
@@ -425,7 +424,7 @@ $(function() {
         $(item).append('<a class="preview-button" onclick="mw.ps.openNav(\'' + $(".wikibase-title-label").text() + '\',\'' +
                                                                                $(item).parents(".wikibase-statementgroupview.listview-item").find(".wikibase-statementgroupview-property-label").children().text() + '\',\'' +
                                                                                $(item).parents(".wikibase-statementview.listview-item.wikibase-toolbar-item").find(".wikibase-statementview-mainsnak .wikibase-snakview-value.wikibase-snakview-variation-valuesnak").children().text() + '\',\'' +
-                                                                               container.find(item).closest(".wikibase-snakview.listview-item").find(".external.free").text() + '\'' + ',' + 'this);">Preview</a>');
+                                                                               container.find(item).closest(".wikibase-snakview.listview-item").find(".external.free").text() + '\'' + ',' + '$(this).closest(\'.wikibase-referenceview.listview-item.wikibase-toolbar-item.new-source\').children().find(\'.f2w-button.f2w-source\'))">Preview</a>');
       });
     }
   }

--- a/frontend/freebase2wikidata.js
+++ b/frontend/freebase2wikidata.js
@@ -418,6 +418,18 @@ $(function() {
                          '</div>');
   })();
 
+  function appendPreviewButton(container){
+    if(container.find(".external.free").length > 0){
+      var refs = container.find(".wikibase-snakview-property");
+      refs.each(function(index, item) {
+        $(item).append('<a class="preview-button" onclick="mw.ps.openNav(\'' + $(".wikibase-title-label").text() + '\',\'' +
+                                                                               $(item).parents(".wikibase-statementgroupview.listview-item").find(".wikibase-statementgroupview-property-label").children().text() + '\',\'' +
+                                                                               $(item).parents(".wikibase-statementview.listview-item.wikibase-toolbar-item").find(".wikibase-statementview-mainsnak .wikibase-snakview-value.wikibase-snakview-variation-valuesnak").children().text() + '\',\'' +
+                                                                               container.find(item).closest(".wikibase-snakview.listview-item").find(".external.free").text() + '\'' + ',' + 'this);">Preview</a>');
+      });
+    }
+  }
+
   var dataset = mw.cookie.get('ps-dataset', null, '');
   var windowManager;
 
@@ -1334,11 +1346,7 @@ $(function() {
       }
       container = container.querySelector('.wikibase-listview');
       container.appendChild(fragment);
-      var tmp = $(container).find(".wikibase-snakview.listview-item");
-      tmp.find(".wikibase-snakview-property").append('<a class="preview-button" onclick="mw.ps.openNav(\'' + $(".wikibase-title-label").text() + '\',\'' +
-                                                                                    tmp.parents(".wikibase-statementgroupview.listview-item").find(".wikibase-statementgroupview-property-label").children().text() + '\',\'' +
-                                                                                    tmp.parents(".wikibase-statementview.listview-item.wikibase-toolbar-item").find(".wikibase-statementview-mainsnak .wikibase-snakview-value.wikibase-snakview-variation-valuesnak").children().text() + '\',\'' +
-                                                                                    tmp.find(".external.free").text() + '\'' + ',' + 'this);">Preview</a>');
+      appendPreviewButton($(container).children().last());
     });
   }
 
@@ -1352,16 +1360,7 @@ $(function() {
           .querySelector('.wikibase-statementlistview-listview');
       container.appendChild(fragment);
       appendToNav(document.getElementById(property));
-      var tmp = $(container).children().last();
-      if(tmp.find(".external.free").length > 0){
-    	  var refs = tmp.find(".wikibase-snakview-property");
-    	  refs.each(function(index, item) {
-    		  $(item).append('<a class="preview-button" onclick="mw.ps.openNav(\'' + $(".wikibase-title-label").text() + '\',\'' +
-                                                                                 $(item).parents(".wikibase-statementgroupview.listview-item").find(".wikibase-statementgroupview-property-label").children().text() + '\',\'' +
-                                                                                 $(item).parents(".wikibase-statementview.listview-item.wikibase-toolbar-item").find(".wikibase-statementview-mainsnak .wikibase-snakview-value.wikibase-snakview-variation-valuesnak").children().text() + '\',\'' +
-                                                                                 tmp.find(item).closest(".wikibase-snakview.listview-item").find(".external.free").text() + '\'' + ',' + 'this);">Preview</a>');
-    	  });
-      }
+      appendPreviewButton($(container).children().last());
     });
   }
 
@@ -1421,16 +1420,7 @@ $(function() {
         fragment.appendChild(child.firstChild);
         container.appendChild(fragment);
         appendToNav(container.lastChild);
-        var tmp = $(container).children().last();
-        if(tmp.find(".external.free").length > 0){
-    	    var refs = tmp.find(".wikibase-snakview-property");
-    	    refs.each(function(index, item) {
-    		    $(item).append('<a class="preview-button" onclick="mw.ps.openNav(\'' + $(".wikibase-title-label").text() + '\',\'' +
-                                                                                   $(item).parents(".wikibase-statementgroupview.listview-item").find(".wikibase-statementgroupview-property-label").children().text() + '\',\'' +
-                                                                                   $(item).parents(".wikibase-statementview.listview-item.wikibase-toolbar-item").find(".wikibase-statementview-mainsnak .wikibase-snakview-value.wikibase-snakview-variation-valuesnak").children().text() + '\',\'' +
-                                                                                   tmp.find(item).closest(".wikibase-snakview.listview-item").find(".external.free").text() + '\'' + ',' + 'this);">Preview</a>');
-    	    });
-        }
+        appendPreviewButton($(container).children().last());
     	});
     });
   }

--- a/frontend/freebase2wikidata.js
+++ b/frontend/freebase2wikidata.js
@@ -34,7 +34,6 @@
 */
 
 $(function() {
-  'use strict';
 
   var async = module.exports;
 
@@ -260,8 +259,8 @@ $(function() {
     var title = mw.config.get('wgTitle');
     return qidRegEx.test(title) ? title : false;
   }
-  
-  (function generateNav() { 
+
+  (function generateNav() {
     $('#mw-panel').append('<div class="portal" role="navigation" id="p-ps-navigation" aria-labelledby="p-ps-navigation-label"><h3 id="p-ps-navigation-label">Browse Primary Sources</h3></div>');
     var navigation =  $('#p-ps-navigation');
     navigation.append('<div class="body"><ul id="p-ps-nav-list"></ul></div>');
@@ -292,7 +291,7 @@ $(function() {
       }
     });
   }
-  
+
   var anchorList = [];
 
   function alphaPos(text){
@@ -331,7 +330,7 @@ $(function() {
         });
       }
     }
-  } 
+  }
 
   var dataset = mw.cookie.get('ps-dataset', null, '');
   var windowManager;

--- a/frontend/freebase2wikidata.js
+++ b/frontend/freebase2wikidata.js
@@ -299,23 +299,20 @@ $(function() {
                                             linklist.append(('<li>' + '<strong>' + key + '</strong>' + ': ' + item[key] + '</li>').replace(regEx, '<span class="highlight">$1</span>'));
                                         }
                                     }
-                                }
-                                else {
+                                } else {
                                     linklist.append(('<li>' + '<strong>' + index + '</strong>' + ': ' + item + '</li>').replace(regEx, '<span class="highlight">$1</span>'));
                                 }
                             }
                         }
-                    }
-                    else{
+                    } else {
                         blackboard.append('<h1><a href="' + data.url + '">' + data.url + '</a></h1>');
                         if(data.content === ''|| data.content == '<body></body>'){
                             blackboard.append('<p>Preview not available for this reference.</p>');
-                        }
-                        else{
+                        } else {
                             blackboard.append($.parseHTML(data.content.replace(/<a[^>]*>(.*?)<\/a>/g, '$1').replace(/<img .*?>/g,'').replace(regEx, '<span class="highlight">$1</span>')));
                         }
                     }
-                }else{
+                } else {
                     blackboard.append('<h1>Preview not available for this reference.</h1>');
                 }
             },
@@ -398,8 +395,7 @@ $(function() {
         anchorList.splice(pos, 0, text_nospace);
         if(pos === 0){
           $('#p-ps-nav-list').prepend('<li id="n-ps-anchor-' + text_nospace + '"><a href="#" title="move to ' + text_space + '">' + text_space + '</a></li>');
-        }
-        else{
+        } else {
           $('#n-ps-anchor-' + anchorList[pos-1]).after('<li id="n-ps-anchor-' + text_nospace + '"><a href="#" title="move to ' + text_space + '">' + text_space + '</a></li>');
         }
         $('#n-ps-anchor-' + text_nospace).click(function(e) {


### PR DESCRIPTION
This PR will add a new feature to the PST.

The referencePreview feature will enable the user to preview (and to approve or reject) a reference without opening it in another tab.

![image](https://user-images.githubusercontent.com/1914074/32957864-26776e68-cbbd-11e7-8e05-8aa80b782dde.png)

If the reference is fetched from a dataset that makes its corpus available (e.g. StrepHit) the corpus itself will be used to create a preview.

![image](https://user-images.githubusercontent.com/1914074/32957918-4796d2dc-cbbd-11e7-8cf8-bd4393633e36.png)

If the corpus is not available (e.g. Freebase) a generic scraper will be used to create a "best effort" preview.

![image](https://user-images.githubusercontent.com/1914074/32957843-190efb42-cbbd-11e7-8643-edbbe6b2366a.png)

In the preview the item label, the property label and the value will be highlighted (yellow marker in the previous image) through text search.
