### PR TITLE
fix uri encoding in preview module

### DIFF
--- a/frontend/freebase2wikidata.js
+++ b/frontend/freebase2wikidata.js
@@ -273,7 +273,7 @@ $(function() {
 
         $.ajax({
             type: 'GET',
-            url: 'https://tools.wmflabs.org/strephit/search?url=' + encodeURI(referenceURL),
+            url: 'https://tools.wmflabs.org/strephit/search?url=' + encodeURIComponent(referenceURL),
             success: function(msg) {
                 $('.loader').remove();
 
@@ -285,7 +285,7 @@ $(function() {
                     {
                         blackboard.append('<h1><a href="' + data.url + '">' + data.url + '</a></h1>');
                         blackboard.append('<ul></ul>');
-                        
+
                         var linklist = $('#blackboard > ul');
                         for(var index in data){
                             var item = data[index];


### PR DESCRIPTION
This will fix the requests for urls with extra tokens/parameters in them.

like:

https://tools.wmflabs.org/strephit/search?url=http://www.genealogics.org/getperson.php?personID=I00446836&tree=LEO

will become

http%3A%2F%2Fwww.genealogics.org%2Fgetperson.php%3FpersonID%3DI00446836%26tree%3DLEO